### PR TITLE
Move `impl AppLabel for` into derive statement

### DIFF
--- a/_release-content/migration-guides/app_label.md
+++ b/_release-content/migration-guides/app_label.md
@@ -3,20 +3,20 @@ title: "Further constraints on `AppLabel`"
 pull_requests: [23377]
 ---
 
-`AppLabel` needs some extra constraints
+`AppLabel` has some extra constraints. It now requires an implementation of `Default` and `Copy`.
+
+To access `.intern()` on an `AppLabel`, you must now import the `AppLabelInterior` trait.
 
 Before:
 
 ```rust,ignore
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
+#[derive(Debug, Hash, PartialEq, Eq, AppLabel)]
 struct MyAppLabel;
 ```
 
 After:
 
 ```rust,ignore
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabelInterior)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
 struct MyAppLabel;
-
-impl AppLabel for MyAppLabel {}
 ```

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -7,7 +7,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-pub use bevy_derive::AppLabelInterior;
+pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     component::RequiredComponentsError,
     error::{ErrorHandler, FallbackErrorHandler},
@@ -38,8 +38,9 @@ use std::{
 
 bevy_ecs::define_label!(
     /// A strongly-typed class of labels used to identify an [`App`].
+    /// Use this type to access `intern()` on an [`AppLabel`].
     #[diagnostic::on_unimplemented(
-        note = "consider annotating `{Self}` with `#[derive(AppLabelInterior)]`"
+        note = "consider annotating `{Self}` with `#[derive(AppLabel)]`"
     )]
     AppLabelInterior,
     APP_LABEL_INTERIOR_INTERNER
@@ -1739,13 +1740,13 @@ mod tests {
 
     #[test]
     fn test_derive_app_label() {
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct UnitLabel;
 
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct TupleLabel(u32, u32);
 
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct StructLabel {
             a: u32,
             b: u32,
@@ -1755,17 +1756,17 @@ mod tests {
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyTupleLabel();
 
         #[expect(
             dead_code,
             reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."
         )]
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct EmptyStructLabel {}
 
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         enum EnumLabel {
             #[default]
             Unit,
@@ -1776,8 +1777,8 @@ mod tests {
             },
         }
 
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-        struct GenericLabel<T>(PhantomData<T>);
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        struct GenericLabel<T: Eq>(PhantomData<T>);
 
         assert_eq!(UnitLabel.intern(), UnitLabel.intern());
         assert_eq!(EnumLabel::Unit.intern(), EnumLabel::Unit.intern());
@@ -1876,10 +1877,8 @@ mod tests {
 
     #[test]
     fn test_extract_sees_changes() {
-        #[derive(AppLabelInterior, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         struct MySubApp;
-
-        impl AppLabel for MySubApp {}
 
         #[derive(Resource)]
         struct Foo(usize);

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1778,7 +1778,7 @@ mod tests {
         }
 
         #[derive(AppLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-        struct GenericLabel<T: Eq>(PhantomData<T>);
+        struct GenericLabel<T>(PhantomData<T>);
 
         assert_eq!(UnitLabel.intern(), UnitLabel.intern());
         assert_eq!(EnumLabel::Unit.intern(), EnumLabel::Unit.intern());

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -26,18 +26,16 @@ type ExtractFn = Box<dyn FnMut(&mut World, &mut World) + Send>;
 /// # Example
 ///
 /// ```
-/// # use bevy_app::{App, SubApp, Main, AppLabel};
-/// # use bevy_derive::AppLabelInterior;
+/// # use bevy_app::{App, SubApp, Main, AppLabel, AppLabelInterior};
+/// # use bevy_derive::AppLabel;
 /// # use bevy_ecs::prelude::*;
 /// # use bevy_ecs::schedule::ScheduleLabel;
 ///
 /// #[derive(Resource, Default)]
 /// struct Val(pub i32);
 ///
-/// #[derive(AppLabelInterior, Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+/// #[derive(AppLabel, Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 /// struct ExampleApp;
-///
-/// impl AppLabel for ExampleApp {}
 ///
 /// // Create an app with a certain resource.
 /// let mut app = App::new();

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -419,7 +419,7 @@ macro_rules! load_internal_binary_asset {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbeddedAssetRegistry, _embedded_asset_path};
+    use super::{_embedded_asset_path, EmbeddedAssetRegistry};
     use std::path::Path;
 
     // Relative paths show up if this macro is being invoked by a local crate.

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -15,8 +15,8 @@ mod enum_variant_meta;
 
 use bevy_macro_utils::{derive_label, BevyManifest};
 use proc_macro::TokenStream;
-use quote::format_ident;
-
+use quote::{format_ident, quote, quote_spanned};
+use syn::spanned::Spanned;
 /// Implements [`Deref`] for structs. This is especially useful when utilizing the [newtype] pattern.
 ///
 /// For single-field structs, the implementation automatically uses that field.
@@ -222,16 +222,52 @@ pub fn derive_enum_variant_meta(input: TokenStream) -> TokenStream {
     enum_variant_meta::derive_enum_variant_meta(input)
 }
 
-/// Generates an impl of the `AppLabelInterior` trait.
+/// Generates an impl of the `AppLabel` trait.
 ///
 /// This does not work for unions.
-#[proc_macro_derive(AppLabelInterior)]
-pub fn derive_app_label_label(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(AppLabel)]
+pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    if let syn::Data::Union(_) = &input.data {
+        let message = "Cannot derive AppLabel for unions.";
+        return quote_spanned! {
+            input.span() => compile_error!(#message);
+        }
+        .into();
+    }
 
-    let mut trait_path = BevyManifest::shared(|manifest| manifest.get_path("bevy_app"));
-    trait_path
+    // First, implement the AppLabelInterior trait.
+    let mut interior_trait_path = BevyManifest::shared(|manifest| manifest.get_path("bevy_app"));
+    interior_trait_path
         .segments
         .push(format_ident!("AppLabelInterior").into());
-    derive_label(input, "AppLabelInterior", &trait_path)
+    let interior_derive_label =
+        derive_label(input.clone(), "AppLabelInterior", &interior_trait_path);
+
+    // Then, implement the AppLabel trait.
+    let mut app_label_trait_path = BevyManifest::shared(|manifest| manifest.get_path("bevy_app"));
+    app_label_trait_path
+        .segments
+        .push(format_ident!("AppLabel").into());
+    let ident = input.ident.clone();
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let mut app_label_where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
+        where_token: Default::default(),
+        predicates: Default::default(),
+    });
+    app_label_where_clause.predicates.push(
+        syn::parse2(quote! {
+            // AppLabel has additional constraints of Default + Copy
+            Self: #interior_trait_path + Copy + Default
+        })
+        .unwrap(),
+    );
+    let app_label_impl = TokenStream::from(quote! {
+        impl #impl_generics #app_label_trait_path for #ident #ty_generics #app_label_where_clause {}
+    });
+
+    interior_derive_label
+        .into_iter()
+        .chain(app_label_impl)
+        .collect()
 }

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -258,7 +258,7 @@ pub fn derive_app_label(input: TokenStream) -> TokenStream {
     app_label_where_clause.predicates.push(
         syn::parse2(quote! {
             // AppLabel has additional constraints of Default + Copy
-            Self: #interior_trait_path + Copy + Default
+            Self: #interior_trait_path + Clone + Copy + Default + PartialEq + Eq
         })
         .unwrap(),
     );

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -342,10 +342,8 @@ impl Render {
 pub(crate) struct FutureRenderResources(Arc<Mutex<Option<RenderResources>>>);
 
 /// A label for the rendering sub-app.
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabelInterior)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
 pub struct RenderApp;
-
-impl AppLabel for RenderApp {}
 
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderSystems`] and creates the rendering sub-app.

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -1,6 +1,6 @@
 use async_channel::{Receiver, Sender};
 
-use bevy_app::{App, AppExit, AppLabel, AppLabelInterior, Plugin, SubApp};
+use bevy_app::{App, AppExit, AppLabel, Plugin, SubApp};
 use bevy_ecs::{
     resource::Resource,
     schedule::MainThreadExecutor,
@@ -14,10 +14,8 @@ use crate::RenderApp;
 ///
 /// The Main schedule of this app can be used to run logic after the render schedule starts, but
 /// before I/O processing. This can be useful for something like frame pacing.
-#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabelInterior)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
 pub struct RenderExtractApp;
-
-impl AppLabel for RenderExtractApp {}
 
 /// Channels used by the main app to send and receive the render app.
 #[derive(Resource)]


### PR DESCRIPTION
For your consideration: Does this do what you were aiming for but with better UX?

Instead of changing `define_label`, I just updated the derive for app label to also include the empty `impl AppLabel for`.